### PR TITLE
Bug fixes for 8 and 16 bits

### DIFF
--- a/core/src/rrc.h
+++ b/core/src/rrc.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "util/assertion.h"
 #include "util/bitwise.h"
 
 namespace tfr {
-
 enum class rrc_type {
 	identity,
 	reverse,
@@ -12,15 +14,15 @@ enum class rrc_type {
 	reverse_complement
 };
 
-const auto rrc_types = {rrc_type::identity, rrc_type::reverse, rrc_type::complement, rrc_type::reverse_complement};
+constexpr auto rrc_types = {rrc_type::identity, rrc_type::reverse, rrc_type::complement, rrc_type::reverse_complement};
 
 template <typename T>
 T permute(T c, int rot, rrc_type type) {
 	switch (type) {
-	case rrc_type::identity: return ror(c, rot);
-	case rrc_type::reverse: return ror(reverse_bits(c), rot);
-	case rrc_type::complement: return ror(~c, rot);
-	case rrc_type::reverse_complement: return ror(~reverse_bits(c), rot);
+	case rrc_type::identity: return ror<T>(c, rot);
+	case rrc_type::reverse: return ror<T>(reverse_bits(c), rot);
+	case rrc_type::complement: return ror<T>(~c, rot);
+	case rrc_type::reverse_complement: return ror<T>(~reverse_bits(c), rot);
 	}
 	assertion(false, "unknown type");
 	return 0;
@@ -47,6 +49,4 @@ std::vector<T> get_rrc_permutations(T x) {
 	}
 	return xs;
 }
-
-
 }

--- a/core/src/statistics/uniform.h
+++ b/core/src/statistics/uniform.h
@@ -3,10 +3,12 @@
 #include "chi2.h"
 
 namespace tfr {
-
 template <typename T>
 sub_test_results uniform_test(const uint64_t n, const stream<T>& source) {
-	return main_sub_test(chi2_uniform_stats(ranged_stream(rescale_type_to_01(source), n)));
+	return main_sub_test(
+		chi2_uniform_stats(ranged_stream(rescale_type_to_01(source), n),
+		                   create_bin_count_pow2<T>()
+		)
+	);
 }
-
 }

--- a/core/src/util/bitwise.h
+++ b/core/src/util/bitwise.h
@@ -28,12 +28,14 @@ constexpr int shift_sizeof() {
 template <typename T>
 T ror(T v, int r) {
 	constexpr auto Bits = bit_sizeof<T>();
+	assertion(r >= 0 && r < Bits, "ror out of range, should be in range 0 < r < bits in type");
 	return (v << r) | (v >> (Bits - r));
 }
 
 template <typename T>
 T rol(T v, int r) {
 	constexpr auto Bits = bit_sizeof<T>();
+	assertion(r >= 0 && r < Bits, "rol out of range, should be in range 0 < r < bits in type");
 	return (v >> r) | (v << (Bits - r));
 }
 

--- a/impl/src/combiners16.h
+++ b/impl/src/combiners16.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "combiner.h"
+
+namespace tfr {
+using combiner16 = combiner<uint16_t>;
+
+namespace combine16 {
+}
+
+template <>
+inline std::vector<combiner16> get_combiners() {
+	return {};
+}
+}

--- a/impl/src/combiners8.h
+++ b/impl/src/combiners8.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "combiner.h"
+
+namespace tfr {
+using combiner8 = combiner<uint8_t>;
+
+namespace combine8 {
+}
+
+template <>
+inline std::vector<combiner8> get_combiners() {
+	return {};
+}
+}

--- a/impl/src/mixers16.h
+++ b/impl/src/mixers16.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vector>
+#include "mixer.h"
+
+namespace tfr {
+using mixer16 = mixer<uint16_t>;
+
+namespace mix16 {
+const mixer16 xm3x = {
+	"mix16::xm3x", [](uint16_t x) {
+		constexpr uint16_t C = 13487;
+		x ^= (x >> 8);
+		x *= C;
+		x ^= (x >> 7);
+		x *= C;
+		x ^= (x >> 8);
+		x *= C;
+		x ^= (x >> 7);
+		return x;
+	}
+};
+}
+
+
+template <>
+inline mixer16 get_default_mixer() {
+	return mix16::xm3x;
+}
+
+template <>
+inline std::vector<mixer16> get_mixers() {
+	return {
+		mix16::xm3x,
+	};
+}
+}

--- a/impl/src/mixers8.h
+++ b/impl/src/mixers8.h
@@ -4,13 +4,11 @@
 #include "mixer.h"
 
 namespace tfr {
-
 using mixer8 = mixer<uint8_t>;
 
 namespace mix8 {
-
 const mixer8 xm3x = {
-	"mix8::xm3x-8", [](uint8_t x) {
+	"mix8::xm3x", [](uint8_t x) {
 		constexpr uint8_t C = 119;
 		x ^= (x >> 4);
 		x *= C;
@@ -22,19 +20,6 @@ const mixer8 xm3x = {
 		return x;
 	}
 };
-
-const mixer8 xm2x = {
-	"mix8::xm2x-8", [](uint8_t x) {
-		constexpr uint8_t C = 117;
-		x ^= x >> 4;
-		x *= C;
-		x ^= x >> 3;
-		x *= C;
-		x ^= x >> 2;
-		return x;
-	}
-};
-
 }
 
 
@@ -47,8 +32,6 @@ template <>
 inline std::vector<mixer8> get_mixers() {
 	return {
 		mix8::xm3x,
-		mix8::xm2x,
 	};
 }
-
 }

--- a/impl/src/prngs16.h
+++ b/impl/src/prngs16.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "prngs32.h"
+
+namespace tfr {
+using prng16 = prng<uint16_t>;
+
+namespace rng16 {
+inline prng16 splitmix_64(const seed_data& seed) {
+	return {
+		"rng16::splitmix_64", [rng_64 = rng64::splitmix(seed)]() mutable {
+			return static_cast<uint16_t>(rng_64() >> 48);
+		}
+	};
+}
+
+inline prng16 pcg_64(const seed_data& seed) {
+	return {
+		"rng16::pcg_64", [rng_64 = rng64::pcg(seed)]() mutable {
+			return static_cast<uint16_t>(rng_64());
+		}
+	};
+}
+}
+
+
+template <>
+inline std::vector<prng_factory<uint16_t>> get_prngs() {
+	return {
+		rng16::splitmix_64,
+		rng16::pcg_64,
+	};
+}
+}

--- a/impl/src/prngs8.h
+++ b/impl/src/prngs8.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "prngs64.h"
+
+namespace tfr {
+using prng8 = prng<uint8_t>;
+
+namespace rng8 {
+inline prng8 splitmix_64(const seed_data& seed) {
+	return {
+		"rng8::splitmix_64", [rng_64 = rng64::splitmix(seed)]() mutable {
+			return static_cast<uint8_t>(rng_64() >> 56);
+		}
+	};
+}
+
+inline prng8 pcg_64(const seed_data& seed) {
+	return {
+		"rng8::pcg_64", [rng_64 = rng64::pcg(seed)]() mutable {
+			return static_cast<uint8_t>(rng_64());
+		}
+	};
+}
+}
+
+
+template <>
+inline std::vector<prng_factory<uint8_t>> get_prngs() {
+	return {
+		rng8::splitmix_64,
+		rng8::pcg_64
+	};
+}
+}

--- a/tool/src/command/test_command.h
+++ b/tool/src/command/test_command.h
@@ -1,17 +1,22 @@
 #pragma once
 
+#include "combiners8.h"
+#include "combiners16.h"
 #include "combiners32.h"
+#include "combiners64.h"
 #include "evaluate.h"
 #include "format_result.h"
+#include "mixers8.h"
+#include "mixers16.h"
 #include "mixers32.h"
 #include "mixers64.h"
-#include "mixers8.h"
+#include "prngs8.h"
+#include "prngs16.h"
 #include "prngs32.h"
 #include "prngs64.h"
 #include "util/test_setups.h"
 
 namespace tfr {
-
 using on_done_callback = std::function<void(test_battery_result, bool pass)>;
 
 inline auto create_result_callback(bool print_intermediate_results = true, const on_done_callback& on_done = {}) {
@@ -83,6 +88,4 @@ void test_command() {
 		evaluate_multi_pass(callback, create_combiner_test_setup<T>(combiner).range(10, max_power_of_two));
 	}
 }
-
-
 }

--- a/tool/src/main.cpp
+++ b/tool/src/main.cpp
@@ -49,6 +49,8 @@ int main(int argc, char** args) {
 		const std::string command = args[2];
 		std::cout << "Executing command " << command << "\n";
 		if (command == "-test") {
+			test_command<uint8_t>();
+			test_command<uint16_t>();
 			test_command<uint32_t>();
 			test_command<uint64_t>();
 			return 0;
@@ -59,6 +61,8 @@ int main(int argc, char** args) {
 			return 0;
 		}
 		if (command == "-inspect-test") {
+			inspect_test_command<uint8_t>();
+			inspect_test_command<uint16_t>();
 			inspect_test_command<uint32_t>();
 			inspect_test_command<uint64_t>();
 			inspect_per_test_command<uint32_t>();

--- a/unittest/src/rrc_test.cpp
+++ b/unittest/src/rrc_test.cpp
@@ -1,0 +1,25 @@
+#include <rrc.h>
+#include "testutil.h"
+
+#include <gtest/gtest.h>
+
+namespace tfr {
+TEST(rrc, rrc_8) {
+	using T = uint8_t;
+	EXPECT_EQ(permute<T>(1, 0, rrc_type::identity), 1);
+	EXPECT_EQ(permute<T>(1, 1, rrc_type::identity), 2);
+	EXPECT_EQ(permute<T>(1, 7, rrc_type::identity), 128);
+
+	EXPECT_EQ(permute<T>(1, 0, rrc_type::reverse), 128);
+	EXPECT_EQ(permute<T>(1, 1, rrc_type::reverse), 1);
+	EXPECT_EQ(permute<T>(1, 7, rrc_type::reverse), 64);
+
+	EXPECT_EQ(permute<T>(1, 0, rrc_type::complement), 254);
+	EXPECT_EQ(permute<T>(1, 1, rrc_type::complement), 253);
+	EXPECT_EQ(permute<T>(1, 7, rrc_type::complement), 127);
+
+	EXPECT_EQ(permute<T>(1, 0, rrc_type::reverse_complement), 127);
+	EXPECT_EQ(permute<T>(1, 1, rrc_type::reverse_complement), 254);
+	EXPECT_EQ(permute<T>(1, 7, rrc_type::reverse_complement), 191);
+}
+}

--- a/unittest/src/statistics/chi2_test.cpp
+++ b/unittest/src/statistics/chi2_test.cpp
@@ -5,6 +5,16 @@
 #include "testutil.h"
 
 namespace tfr {
+template <typename T>
+std::optional<statistic> chi2_stats_from_test_stream(uint64_t n, const bin_count_function& bin_counter) {
+	auto s = test_stream();
+	std::vector<double> a;
+	a.reserve(n);
+	while (a.size() < n) {
+		a.push_back(rescale_type_to_01(static_cast<T>(s())));
+	}
+	return chi2_uniform_stats(a, bin_counter);
+}
 
 TEST(chi2, unset) {
 	EXPECT_FALSE(chi2_stats({}, 0));
@@ -13,24 +23,20 @@ TEST(chi2, unset) {
 
 TEST(chi2, basic) {
 	using T = std::vector<double>;
+
 	// same as mma
-	EXPECT_NEAR(chi2_uniform_stats<T>({0})->value, 1, 1e-4);
-	EXPECT_NEAR(chi2_uniform_stats<T>({0, 0})->value, 4, 1e-4);
-	EXPECT_EQ(chi2_uniform_stats<T>({0.1})->value, 1);
-	EXPECT_EQ(chi2_uniform_stats<T>({0.1})->df, 1);
-	EXPECT_EQ(chi2_uniform_stats<T>({0.1, 0.1, 0.1, 0.1})->value, 12);
-	EXPECT_EQ(chi2_uniform_stats<T>({0.1, 0.1, 0.1, 0.1})->df, 3);
-	EXPECT_NEAR(chi2_uniform_stats<T>({0.1, 0.2, 0.3, 0.4, 0.5, 0.4, 0.8})->value, 3.71428, 1e-4);
-	EXPECT_EQ(chi2_uniform_stats<T>({0.1, 0.2, 0.3, 0.4, 0.5, 0.4, 0.8})->df, 4);
+	EXPECT_NEAR(chi2_uniform_stats<T>({0}, get_bin_count_mathematica)->value, 1, 1e-4);
+	EXPECT_NEAR(chi2_uniform_stats<T>({0, 0}, get_bin_count_mathematica)->value, 4, 1e-4);
+	EXPECT_EQ(chi2_uniform_stats<T>({0.1}, get_bin_count_mathematica)->value, 1);
+	EXPECT_EQ(chi2_uniform_stats<T>({0.1}, get_bin_count_mathematica)->df, 1);
+	EXPECT_EQ(chi2_uniform_stats<T>({0.1, 0.1, 0.1, 0.1}, get_bin_count_mathematica)->value, 12);
+	EXPECT_EQ(chi2_uniform_stats<T>({0.1, 0.1, 0.1, 0.1}, get_bin_count_mathematica)->df, 3);
+	EXPECT_NEAR(chi2_uniform_stats<T>({0.1, 0.2, 0.3, 0.4, 0.5, 0.4, 0.8}, get_bin_count_mathematica)->value, 3.71428, 1e-4);
+	EXPECT_EQ(chi2_uniform_stats<T>({0.1, 0.2, 0.3, 0.4, 0.5, 0.4, 0.8}, get_bin_count_mathematica)->df, 4);
 }
 
 TEST(chi2, large) {
-	auto s = test_stream();
-	std::vector<double> a;
-	while (a.size() < 1000000) {
-		a.push_back(rescale_type_to_01(s()));
-	}
-	const auto stat = chi2_uniform_stats(a);
+	const auto stat = chi2_stats_from_test_stream<uint64_t>(1000000, get_bin_count_mathematica);
 	EXPECT_NEAR(stat->value, 485.4309, 1e-4);
 	EXPECT_NEAR(stat->p_value, 0.6941, 1e-4);
 }
@@ -42,7 +48,7 @@ TEST(chi2, data) {
 		0.255059, 0.213638, 0.399358, 0.127307, 0.0803425, 0.535384, 0.479835, 0.332602, 0.313224, 0.74566, 0.586695, 0.31661, 0.622685, 0.319371, 0.387137, 0.956242, 0.852309, 0.117861, 0.34173, 0.278867, 0.590599, 0.846015, 0.308734, 0.346514, 0.583689, 0.632231, 0.257446, 0.499904, 0.0834331, 0.262653, 0.1925,
 		0.332932, 0.786185, 0.584509, 0.288786, 0.538318, 0.292864, 0.102028
 	};
-	const auto s = chi2_uniform_stats(pv);
+	const auto s = chi2_uniform_stats(pv, get_bin_count_mathematica);
 	EXPECT_NEAR(s->value, 8.68, 1e-4); // matches mma
 	EXPECT_NEAR(s->p_value, 0.729992, 1e-4); // matches mma
 }
@@ -55,16 +61,83 @@ TEST(chi2, inconclusive) {
 	EXPECT_FALSE(s);
 }
 
-TEST(chi2, get_bin_count) {
-	EXPECT_EQ(get_bin_count(1), 2);
-	EXPECT_EQ(get_bin_count(2), 3);
-	EXPECT_EQ(get_bin_count(3), 4);
-	EXPECT_EQ(get_bin_count(10), 6);
-	EXPECT_EQ(get_bin_count(100), 13);
-	EXPECT_EQ(get_bin_count(1000), 32);
-	EXPECT_EQ(get_bin_count(1000000), 503);
-	EXPECT_EQ(get_bin_count(67108864), 2703);
+TEST(chi2, get_bin_count_mathematica) {
+	EXPECT_EQ(get_bin_count_mathematica(1), 2);
+	EXPECT_EQ(get_bin_count_mathematica(2), 3);
+	EXPECT_EQ(get_bin_count_mathematica(3), 4);
+	EXPECT_EQ(get_bin_count_mathematica(10), 6);
+	EXPECT_EQ(get_bin_count_mathematica(100), 13);
+	EXPECT_EQ(get_bin_count_mathematica(1000), 32);
+	EXPECT_EQ(get_bin_count_mathematica(1000000), 503);
+	EXPECT_EQ(get_bin_count_mathematica(67108864), 2703);
 }
 
+TEST(chi2, get_bin_count_pow2_8) {
+	auto bc = create_bin_count_pow2<uint8_t>();
+	EXPECT_EQ(bc(1), 2);
+	EXPECT_EQ(bc(2), 4);
+	EXPECT_EQ(bc(3), 4);
+	EXPECT_EQ(bc(10), 8);
+	EXPECT_EQ(bc(100), 16);
+	EXPECT_EQ(bc(1000), 32);
+	EXPECT_EQ(bc(1000000), 256);
+	EXPECT_EQ(bc(67108864), 256);
+}
+
+TEST(chi2, get_bin_count_pow2_16) {
+	auto bc = create_bin_count_pow2<uint16_t>();
+	EXPECT_EQ(bc(1), 2);
+	EXPECT_EQ(bc(2), 4);
+	EXPECT_EQ(bc(3), 4);
+	EXPECT_EQ(bc(10), 8);
+	EXPECT_EQ(bc(100), 16);
+	EXPECT_EQ(bc(1000), 32);
+	EXPECT_EQ(bc(1000000), 512);
+	EXPECT_EQ(bc(67108864), 4096);
+	EXPECT_EQ(bc(1ull<<34), 32768);
+	EXPECT_EQ(bc(1ull<<35), 65536);
+	EXPECT_EQ(bc(1ull<<36), 65536);
+	EXPECT_EQ(bc(1ull<<40), 65536);
+}
+
+TEST(chi2, get_bin_count_pow2_32) {
+	auto bc = create_bin_count_pow2<uint32_t>();
+	EXPECT_EQ(bc(1), 2);
+	EXPECT_EQ(bc(2), 4);
+	EXPECT_EQ(bc(3), 4);
+	EXPECT_EQ(bc(10), 8);
+	EXPECT_EQ(bc(100), 16);
+	EXPECT_EQ(bc(1ull<<40), 262144);
+	EXPECT_EQ(bc(1ull<<50), 4194304);
+	EXPECT_EQ(bc(1ull<<63), 134217728);
+}
+
+TEST(chi2, uniform_8) {
+	using T = uint8_t;
+	const auto stat = chi2_stats_from_test_stream<T>(1 << 22, create_bin_count_pow2<T>());
+	EXPECT_NEAR(stat->value, 254.0640, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.5047, 1e-4);
+}
+
+TEST(chi2, uniform_16) {
+	using T = uint16_t;
+	const auto stat = chi2_stats_from_test_stream<T>(1 << 22, create_bin_count_pow2<T>());
+	EXPECT_NEAR(stat->value, 1020.8432, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.5131, 1e-4);
+}
+
+TEST(chi2, uniform_32) {
+	using T = uint32_t;
+	const auto stat = chi2_stats_from_test_stream<T>(1 << 22, create_bin_count_pow2<T>());
+	EXPECT_NEAR(stat->value, 985.0458, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.7981, 1e-4);
+}
+
+TEST(chi2, uniform_64) {
+	using T = uint64_t;
+	const auto stat = chi2_stats_from_test_stream<T>(1 << 22, create_bin_count_pow2<T>());
+	EXPECT_NEAR(stat->value, 1036.2822, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.3793, 1e-4);
+}
 
 }

--- a/unittest/src/util/bitwise_test.cpp
+++ b/unittest/src/util/bitwise_test.cpp
@@ -52,6 +52,7 @@ TEST(bitwise, reverse_bits_8) {
 	EXPECT_EQ(reverse_bits<uint8_t>(1), 0b10000000);
 	EXPECT_EQ(reverse_bits<uint8_t>(3), 0b11000000);
 	EXPECT_EQ(reverse_bits<uint8_t>(0b11010010), 0b01001011);
+	EXPECT_EQ(reverse_bits<uint8_t>(128), 0b00000001);
 }
 
 TEST(bitwise, reverse_bits_16) {


### PR DESCRIPTION
This fixes a few problems with 8 and 16 bits:

* The bin count of the uniform test's chi square is using sizes of power of two. This will prevent bias (this bias is only significant in 8 and 16 bits).
* Also make sure we don't use more bins than unique values (can only happen with 8 and 16 bits)
* The rrc for 8 bits had a bug when taking the complement making tests fail.