### PR TITLE
Gap fix for 8 bits

### DIFF
--- a/core/src/statistics/gap.h
+++ b/core/src/statistics/gap.h
@@ -45,7 +45,7 @@ template <typename T>
 sub_test_results gap_test(uint64_t n, const stream<T>& source) {
 	sub_test_results results;
 
-	for (int wanted_gaps = 3; wanted_gaps <= 3; ++wanted_gaps) {
+	for (int wanted_gaps = 4; wanted_gaps <= 4; ++wanted_gaps) {
 		const double gap_size = 1. / static_cast<double>(wanted_gaps);
 		const uint64_t expected_total_count = n / wanted_gaps;
 		for (int gi = 0; gi < wanted_gaps; ++gi) {

--- a/unittest/src/statistics/avalanche_test.cpp
+++ b/unittest/src/statistics/avalanche_test.cpp
@@ -6,7 +6,6 @@
 #include "testutil.h"
 
 namespace tfr {
-
 TEST(avalanche, sac_data_no_change) {
 	EXPECT_EQ(hash64(avalanche_generate_sac(10, test_stream(), mix64::mx3)), 1240375597136458279ull);
 }
@@ -20,20 +19,19 @@ TEST(avalanche, sac_data_large) {
 	constexpr auto n = 200000;
 	const auto counts = avalanche_generate_sac<T>(n, test_stream<T>(), get_default_mixer<T>());
 	auto s = avalanche_sac_stats<T>(n, counts);
-	EXPECT_NEAR(s->value, 19.7613, 1e-4);
-	EXPECT_NEAR(s->p_value, 0.8027, 1e-4);
+	EXPECT_NEAR(s->value, 29.1370, 1e-4);
+	EXPECT_NEAR(s->p_value, 0.3048, 1e-4);
 }
 
 TEST(avalanche, sac_no_change) {
 	const auto r = avalanche_mixer_sac_test(50, test_stream(), mix64::mx3).front().stats;
-	EXPECT_NEAR(r->value,  17.1819, 1e-4);
+	EXPECT_NEAR(r->value, 17.1819, 1e-4);
 	EXPECT_NEAR(r->p_value, 0.7532, 1e-4);
 }
 
 TEST(avalanche, bic_no_change) {
 	const auto r = avalanche_mixer_bic_test(50, test_stream(), mix64::mx3).front().stats;
-	EXPECT_NEAR(r->value,  4020.4800, 1e-4);
+	EXPECT_NEAR(r->value, 4020.4800, 1e-4);
 	EXPECT_NEAR(r->p_value, 0.7942, 1e-4);
 }
-
 }

--- a/unittest/src/statistics/divisibility_test.cpp
+++ b/unittest/src/statistics/divisibility_test.cpp
@@ -6,7 +6,6 @@
 
 
 namespace tfr {
-
 TEST(divisibility, collect_divisbility) {
 	using T = std::vector<uint64_t>;
 	EXPECT_EQ(collect_divisible<T>(2, 1, 4, {1,3,5,2,4}), T({1,0,0,1}));
@@ -30,4 +29,15 @@ TEST(divisibility, divisibility_no_change) {
 	EXPECT_NEAR(r->p_value, 0.6662, 1e-4);
 }
 
+TEST(divisibility, divisibility_no_change_8) {
+	auto s = test_stream();
+	std::vector<uint8_t> data;
+	for (int i = 0; i < (1<<22); ++i) {
+		data.push_back(static_cast<uint8_t>(s()));
+	}
+	const auto s8 = create_stream_from_data_by_ref("test", data);
+	auto r = divisibility_test<uint8_t>(data.size(), s8).front().stats;
+	EXPECT_NEAR(r->value, 11.1800, 1e-4);
+	EXPECT_NEAR(r->p_value, 0.7397, 1e-4);
+}
 }

--- a/unittest/src/statistics/gap_test.cpp
+++ b/unittest/src/statistics/gap_test.cpp
@@ -38,8 +38,21 @@ TEST(gap, generate_gap_probabilities) {
 
 TEST(gap, no_change) {
 	const auto r = gap_test<uint64_t>(1000, test_stream()).front().stats;
-	EXPECT_NEAR(r->value, 5.6005, 1e-4);
-	EXPECT_NEAR(r->p_value, 0.9348, 1e-4);
+	EXPECT_NEAR(r->value, 15.7398, 1e-4);
+	EXPECT_NEAR(r->p_value, 0.3995, 1e-4);
 }
+
+TEST(gap, no_change_8) {
+	auto s = test_stream();
+	std::vector<uint8_t> data;
+	for (int i = 0; i < (1<<22); ++i) {
+		data.push_back(static_cast<uint8_t>(s()));
+	}
+	const auto s8 = create_stream_from_data_by_ref("test", data);
+	auto r = gap_test<uint8_t>(data.size(), s8).front().stats;
+	EXPECT_NEAR(r->value, 21.6820, 1e-4);
+	EXPECT_NEAR(r->p_value, 0.1972, 1e-4);
+}
+
 
 }

--- a/unittest/src/statistics/permutation_test.cpp
+++ b/unittest/src/statistics/permutation_test.cpp
@@ -6,7 +6,6 @@
 
 
 namespace tfr {
-
 template <typename T>
 std::vector<uint64_t> get_histogram(const std::vector<T>& d) {
 	auto s = create_stream_from_data_by_ref<T>("d", d, 0);
@@ -57,6 +56,18 @@ TEST(permutation, histogram) {
 		EXPECT_EQ(h[i], 1);
 	}
 	EXPECT_EQ(accumulate(h), 19);
+}
+
+TEST(permutation, no_change_8) {
+	auto s = test_stream();
+	std::vector<uint8_t> data;
+	for (int i = 0; i < (1 << 20); ++i) {
+		data.push_back(static_cast<uint8_t>(s()));
+	}
+	const auto s8 = create_stream_from_data_by_ref("test", data);
+	const auto r = permutation_test(data.size(), s8).front().stats;
+	EXPECT_NEAR(r->value, 523.6892, 1e-4);
+	EXPECT_NEAR(r->p_value, .3392, 1e-4);
 }
 
 }

--- a/unittest/src/testutil.h
+++ b/unittest/src/testutil.h
@@ -6,11 +6,26 @@
 #include "trng_data.h"
 
 namespace tfr {
-
-
 template <typename T> mixer<T> get_test_mixer();
 
-template <> inline mixer<uint32_t> get_test_mixer() { return mix32::prospector; }
+template <> inline mixer<uint8_t> get_test_mixer() {
+	return {
+		"mix8:mx3_64", [](uint8_t x) { return static_cast<uint8_t>(mix64::mx3(x)); }
+	};
+}
+
+template <> inline mixer<uint16_t> get_test_mixer() {
+	return {
+		"mix16:mx3_64", [](uint16_t x) { return static_cast<uint16_t>(mix64::mx3(x)); }
+	};
+}
+
+template <> inline mixer<uint32_t> get_test_mixer() {
+	return {
+		"mix32:mx3_64", [](uint32_t x) { return static_cast<uint32_t>(mix64::mx3(x)); }
+	};
+}
+
 template <> inline mixer<uint64_t> get_test_mixer() { return mix64::mx3; }
 
 template <typename T = uint64_t>
@@ -27,5 +42,4 @@ uint64_t hash64(const T& data) {
 	}
 	return h;
 }
-
 }


### PR DESCRIPTION
Remove bias in gap test. The bias becomes significant for 8-bit tests. Added a bunch of tests for 8 bit tests to ensure p-values that look reasonable.