### PR TITLE
Update 32-bit combiners

### DIFF
--- a/core/src/streams.h
+++ b/core/src/streams.h
@@ -7,30 +7,19 @@
 #include "combiner.h"
 
 namespace tfr {
-
 template <typename T>
 struct counter_stream {
-	T increment{};
-	T i{};
+	uint64_t increment{};
+	uint64_t state{};
 
 	T operator()() {
-		i += increment;
-		return i;
+		state += increment;
+		return static_cast<T>(state);
 	}
 };
 
 template <typename T>
-struct function_stream {
-	const std::function<T(T)> f;
-	T i{};
-
-	T operator()() {
-		return f(++i);
-	}
-};
-
-template <typename T>
-stream<T> create_counter_stream(T increment, T start) {
+stream<T> create_counter_stream(uint64_t increment, uint64_t start) {
 	return {"counter-" + std::to_string(increment), counter_stream<T>{increment, start}};
 }
 
@@ -40,7 +29,7 @@ stream<T> create_constant_stream(T c) {
 }
 
 template <typename T>
-stream<T> create_counter_stream(T increment) {
+stream<T> create_counter_stream(uint64_t increment) {
 	return create_counter_stream<T>(increment, 0);
 }
 
@@ -100,6 +89,4 @@ stream<T> create_combined_incremental_stream(T seed, stream<T> source, combiner<
 		}
 	};
 }
-
-
 }

--- a/impl/src/combiners32.h
+++ b/impl/src/combiners32.h
@@ -7,39 +7,51 @@ namespace tfr {
 using combiner32 = combiner<uint32_t>;
 
 namespace combine32 {
-const combiner32 xmx = {
-	"combine32::xmx", [](uint32_t x, uint32_t y) {
-		x += 2471660141;
-		y -= 2471660141;
-
-		y ^= (y >> 16);
-		y *= 2471660141;
+const combiner32 mx1 = {
+	"combine32::mx1", [](uint32_t x, uint32_t y) {
+		constexpr uint32_t C = 2471660141U;
+		y ^= y >> 16;
+		y *= C;
 		x ^= y;
-		x ^= (x >> 15);
+		x += C;
+		x ^= x >> 14;
+		x *= C;
+		x ^= x >> 13;
 		return x;
 	}
 };
 
-const combiner32 xm2x = {
-	"combine32::xm2x", [](uint32_t x, uint32_t y) {
-		x += 2471660141;
-		y -= 2471660141;
-
-		y ^= (y >> 16);
-		y *= 2471660141;
+const combiner32 mx2 = {
+	"combine32::mx2", [](uint32_t x, uint32_t y) {
+		constexpr uint32_t C = 1159349557U;
+		y ^= y >> 16;
+		y *= C;
 		x ^= y;
-		x ^= (x >> 15);
-		x *= 2471660141;
-		x ^= (x >> 14);
+		x += C;
+		x ^= x >> 14;
+		x *= C;
+		x ^= x >> 13;
+		x *= C;
+		x ^= x >> 16;
 		return x;
 	}
 };
 
-const combiner32 xm3x = {
-	"combine32::xm3x", [](uint32_t x, uint32_t y) {
-		x += 2471660141;
-		y -= 2471660141;
-		return mix32::mx2(x ^ mix32::mx1(y));
+const combiner32 mx3 = {
+	"combine32::mx3", [](uint32_t x, uint32_t y) {
+		constexpr uint32_t C = 1159349557U;
+		y ^= y >> 16;
+		y *= C;
+		x ^= y;
+		x += C;
+		x ^= x >> 14;
+		x *= C;
+		x ^= x >> 13;
+		x *= C;
+		x ^= x >> 16;
+		x *= C;
+		x ^= x >> 14;
+		return x;
 	}
 };
 
@@ -55,7 +67,7 @@ const combiner32 boost = {
 		};
 
 		x ^= boost_hash(y) + 0x9e3779b9 + (x << 6) + (x >> 2);
-		return x;
+		return x; // 10/15
 	}
 };
 }
@@ -64,9 +76,9 @@ const combiner32 boost = {
 template <>
 inline std::vector<combiner32> get_combiners() {
 	return {
-		combine32::xmx,
-		combine32::xm2x,
-		combine32::xm3x,
+		combine32::mx1,
+		combine32::mx2,
+		combine32::mx3,
 		combine32::boost
 	};
 }

--- a/results/result_32.md
+++ b/results/result_32.md
@@ -24,7 +24,7 @@ rng32::xoshiro128\+\+|>35|
 rng32::mt19937|>35|
 rng32::xorshift|16|bc2d
 rng32::minstd\_rand|10|coupon, gap, mean, permutation, uniform
-combine32::xmx|10|coupon, divisibility, gap, mean, permutation, runs, uniform
-combine32::xm2x|10|coupon, divisibility, gap, runs, uniform
-combine32::xm3x|10|gap
+combine32::mx1|10|coupon, gap, runs
+combine32::mx2|25|bc2d
+combine32::mx3|27|uniform
 combine32::boost|10|coupon, divisibility, gap, mean, permutation, runs, uniform

--- a/tool/src/util/stream_sources.h
+++ b/tool/src/util/stream_sources.h
@@ -5,7 +5,6 @@
 #include "util/algo.h"
 
 namespace tfr {
-
 template <typename T>
 streams<T> create_sources() {
 	return create_rrc_sources<T>({create_counter_stream<T>(1)});
@@ -30,22 +29,20 @@ streams<T> create_combiner_sources(combiner<T> combiner) {
 		create_constant_stream<T>(0),
 		combiner));
 
-	const auto& mix = get_default_mixer<T>();
 	streams<T> streams_a;
 	streams<T> streams_b;
 
 	// a, b
-	constexpr int seed = 0;
-	streams_a.push_back(create_counter_stream<T>(seed + 1, mix(1000 + seed)));
-	streams_b.push_back(create_counter_stream<T>(seed + 1, mix(1 + seed)));
+	streams_a.push_back(create_counter_stream<T>(1, 1));
+	streams_b.push_back(create_counter_stream<T>(1, 2));
 
 	// a, a
-	streams_a.push_back(create_counter_stream<T>(1, mix(seed)));
-	streams_b.push_back(create_counter_stream<T>(1, mix(seed)));
+	streams_a.push_back(create_counter_stream<T>(1, 1ull << 32));
+	streams_b.push_back(create_counter_stream<T>(1, 1ull << 32));
 
 	// a, -a
-	streams_a.push_back(create_counter_stream<T>(1, mix(seed)));
-	streams_b.push_back(create_counter_stream<T>(1, -mix(seed)));
+	streams_a.push_back(create_counter_stream<T>(1, 1));
+	streams_b.push_back(create_counter_stream<T>(-1, 1));
 
 	const auto rrc_a = create_rrc_sources(streams_a);
 	const auto rrc_b = create_rrc_sources(streams_b);
@@ -55,5 +52,4 @@ streams<T> create_combiner_sources(combiner<T> combiner) {
 
 	return sources;
 }
-
 }


### PR DESCRIPTION
Using mixer structure to create combiners. This is helpful to understand how to effectively combine states for prngs.

The structure is as follows (mx1):

```
uint32_t mx1(uint32_t x, uint32_t y) {
  y ^= y >> 16;
  y *= C;               // scramble y (mx1 without last xor shift)
  x ^= y;              // combine x and y
  x += C;              //  add the constant to x (this fixes cases where x or/and y is 0)
  x ^= x >> 14;   // continue mixing...
  x *= C;
  x ^= x >> 13;
  return x;           // note that x only had one multiplication, hence I named it mx1
```