### PR TITLE
Add binary matrix rank test

### DIFF
--- a/core/src/evaluate.h
+++ b/core/src/evaluate.h
@@ -26,6 +26,8 @@ struct test_setup {
 	}
 
 	test_setup& range(int start_power, int stop_power) {
+		assertion(start_power > 0 && start_power <= 63, "Start power should be between 1-63");
+		assertion(stop_power >= start_power && stop_power <= 63, "Start power should be between start_power-63");
 		start_power_of_two = start_power;
 		stop_power_of_two = stop_power;
 		return *this;

--- a/core/src/statistics/binary_rank.h
+++ b/core/src/statistics/binary_rank.h
@@ -108,11 +108,19 @@ std::optional<statistic> binary_rank_stats(uint64_t n, stream<T> stream, uint64_
 	                });
 
 	return chi2_stats(rank_counts.size(), to_data(rank_counts),
-	                  mul(to_data(ps), to_data(matrix_count)), 1.);
+	                  mul(to_data(ps), to_data(matrix_count)), 5.);
+}
+
+template <typename T>
+uint64_t get_matrix_size(uint64_t n) {
+	constexpr double wanted_matrices = 5. / 0.0052387863054258942636;
+	constexpr double multiplier = bit_sizeof<T>() / wanted_matrices;
+	return std::bit_floor(static_cast<uint64_t>(std::sqrt(n * multiplier)));
 }
 
 template <typename T>
 sub_test_results binary_rank_test(uint64_t n, const stream<T>& source) {
-	return main_sub_test(binary_rank_stats(n, source, 32));
+	const auto matrix_size = get_matrix_size<T>(n);
+	return {{std::to_string(matrix_size), binary_rank_stats(n, source, matrix_size)}};
 }
 }

--- a/core/src/statistics/binary_rank.h
+++ b/core/src/statistics/binary_rank.h
@@ -120,6 +120,11 @@ uint64_t get_matrix_size(uint64_t n) {
 
 template <typename T>
 sub_test_results binary_rank_test(uint64_t n, const stream<T>& source) {
+	constexpr auto slow_down = 5. / 7.; // (2^25)^x=(2^35)
+	n = static_cast<uint64_t>(std::pow(n, slow_down));
+	if (n < 1 << 10) {
+		return {};
+	}
 	const auto matrix_size = get_matrix_size<T>(n);
 	return {{std::to_string(matrix_size), binary_rank_stats(n, source, matrix_size)}};
 }

--- a/core/src/statistics/binary_rank.h
+++ b/core/src/statistics/binary_rank.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <deque>
+
+#include "chi2.h"
+#include "util/bitwise.h"
+#include "types.h"
+
+#include <vector>
+
+namespace tfr {
+// todo: unify with other matrix
+using binary_matrix = std::vector<std::vector<int>>;
+
+inline void swap_rows(binary_matrix& matrix, int row1, int row2) {
+	for (size_t i = 0; i < matrix[0].size(); ++i) {
+		std::swap(matrix[row1][i], matrix[row2][i]);
+	}
+}
+
+
+inline uint64_t calculate_rank(binary_matrix m) {
+	const auto rows = m.size();
+	const auto cols = m[0].size();
+	uint64_t rank = 0;
+
+	for (size_t i = 0; i < rows; ++i) {
+		// Find the leftmost non-zero element in the current row
+		size_t col = 0;
+		while (col < cols && m[i][col] == 0) {
+			col++;
+		}
+
+		// If a non-zero element is found, increment the rank
+		if (col < cols) {
+			rank++;
+
+			// Eliminate non-zero elements in the current column in other rows
+			for (size_t j = 0; j < rows; ++j) {
+				if (j != i && m[j][col] == 1) {
+					for (size_t k = 0; k < cols; ++k) {
+						m[j][k] = m[j][k] ^ m[i][k];
+					}
+				}
+			}
+		}
+	}
+
+	return rank;
+}
+
+template <typename RangeT>
+void for_each_matrix(const RangeT& data, uint64_t matrix_size, const std::function<void(const binary_matrix&)>& callback) {
+	binary_matrix tmp_matrix(matrix_size, std::vector(matrix_size, 0));
+
+	for_each_bit(data, [c=0ull, r=0ull, matrix_size, &tmp_matrix, callback](int bit) mutable {
+		tmp_matrix[r][c] = bit;
+		if (++c == matrix_size) {
+			++r;
+			c = 0;
+		}
+		if (c == 0 && r == matrix_size) {
+			callback(tmp_matrix);
+			r = 0;
+		}
+	});
+}
+
+inline double get_rank_probability(uint64_t matrix_size, uint64_t rank) {
+	// from https://eprint.iacr.org/2022/061.pdf 2.1
+	const auto n = static_cast<int64_t>(matrix_size);
+	const auto r = static_cast<int64_t>(rank);
+	const double c = std::pow(2, -(n - r) * (n - r));
+	double p = 1.;
+	for (int64_t i = 0; i < r; ++i) {
+		double numerator = 1. - std::pow(2., i - n);
+		numerator *= numerator;
+		p *= numerator / (1. - std::pow(2., i - r));
+	}
+	return c * p;
+}
+
+inline std::vector<double> get_rank_probabilities(uint64_t matrix_size) {
+	std::deque<double> probabilities;
+	uint64_t rank = 0;
+	double sum = 0;
+	while (rank <= matrix_size) {
+		const auto p = get_rank_probability(matrix_size, rank);
+		probabilities.push_front(p);
+		sum += p;
+		++rank;
+	}
+	assertion(is_near(sum, 1), "Unexpected sum for rank probabilities");
+	return {probabilities.begin(), probabilities.end()};
+}
+
+template <typename T>
+std::optional<statistic> binary_rank_stats(uint64_t n, stream<T> stream, uint64_t matrix_size) {
+	const auto ps = get_rank_probabilities(matrix_size);
+	std::vector<uint64_t> rank_counts(ps.size(), 0);
+	auto matrix_count = 0;
+	for_each_matrix(ranged_stream<T>(stream, n), matrix_size,
+	                [&rank_counts, matrix_size, &matrix_count](const binary_matrix& m) {
+		                const auto r = calculate_rank(m);
+		                const auto s = matrix_size - r;
+		                rank_counts[s]++;
+		                ++matrix_count;
+	                });
+
+	return chi2_stats(rank_counts.size(), to_data(rank_counts),
+	                  mul(to_data(ps), to_data(matrix_count)), 1.);
+}
+
+template <typename T>
+sub_test_results binary_rank_test(uint64_t n, const stream<T>& source) {
+	return main_sub_test(binary_rank_stats(n, source, 32));
+}
+}

--- a/core/src/util/statistic_analysis.h
+++ b/core/src/util/statistic_analysis.h
@@ -7,7 +7,6 @@
 #include <vector>
 
 namespace tfr {
-
 inline std::vector<double> to_statistics(const std::vector<test_result>& results) {
 	std::vector<double> statistics;
 	statistics.reserve(results.size());
@@ -26,7 +25,7 @@ inline std::vector<double> to_p_values(const std::vector<test_result>& results) 
 	return statistics;
 }
 
-inline double get_comparable_p_value(statistic stat) {
+inline double get_comparable_p_value(const statistic& stat) {
 	if (stat.type == statistic_type::z_score) {
 		return stat.p_value;
 	}
@@ -46,7 +45,7 @@ inline test_result get_worst_result(const std::vector<test_result>& test_results
 
 class statistic_analysis {
 public:
-	explicit statistic_analysis(statistic stat) : stat(stat) {
+	explicit statistic_analysis(const statistic& stat) : stat(stat) {
 	}
 
 	bool has_remark() const {
@@ -149,6 +148,4 @@ inline std::optional<statistic_analysis> get_worst_statistic_analysis(const test
 	}
 	return ras.front().analysis;
 }
-
-
 }

--- a/tool/src/command/test_command.h
+++ b/tool/src/command/test_command.h
@@ -65,12 +65,12 @@ void test_command() {
 	const auto file_ns = "file" + std::to_string(bit_sizeof<T>()) + "::";
 	// trng
 	if (const auto* data = get_trng_data<T>()) {
-		evaluate_multi_pass(callback, create_data_test_setup<T>(file_ns + "trng", *data).range(10, 22));
+		evaluate_multi_pass(callback, create_data_test_setup<T>(file_ns + "trng", *data).range(10, std::min(max_power_of_two, 22)));
 	}
 
 	// drng
 	if (const auto* data = get_drng_data<T>()) {
-		evaluate_multi_pass(callback, create_data_test_setup<T>(file_ns + "drng", *data).range(10, 27));
+		evaluate_multi_pass(callback, create_data_test_setup<T>(file_ns + "drng", *data).range(10, std::min(max_power_of_two, 27)));
 	}
 
 	// mixers

--- a/unittest/src/statistics/binary_rank_test.cpp
+++ b/unittest/src/statistics/binary_rank_test.cpp
@@ -1,0 +1,120 @@
+#include <statistics/binary_rank.h>
+
+#include <gtest/gtest.h>
+
+#include "testutil.h"
+
+namespace tfr {
+TEST(binary_rank, calculate_rank_small) {
+	EXPECT_EQ(calculate_rank({{}}), 0);
+	EXPECT_EQ(calculate_rank({{0}}), 0);
+	EXPECT_EQ(calculate_rank({{1}}), 1);
+
+	EXPECT_EQ(calculate_rank({{0,0},{0,0}}), 0);
+
+	EXPECT_EQ(calculate_rank({{1,0},{0,0}}), 1);
+	EXPECT_EQ(calculate_rank({{0,1},{0,0}}), 1);
+	EXPECT_EQ(calculate_rank({{0,0},{1,0}}), 1);
+	EXPECT_EQ(calculate_rank({{0,0},{0,1}}), 1);
+
+	EXPECT_EQ(calculate_rank({{1,1},{0,0}}), 1);
+	EXPECT_EQ(calculate_rank({{1,0},{1,0}}), 1);
+	EXPECT_EQ(calculate_rank({{1,0},{0,1}}), 2);
+	EXPECT_EQ(calculate_rank({{0,1},{1,0}}), 2);
+	EXPECT_EQ(calculate_rank({{0,1},{0,1}}), 1);
+	EXPECT_EQ(calculate_rank({{0,0},{1,1}}), 1);
+
+	EXPECT_EQ(calculate_rank({{1,1},{1,0}}), 2);
+	EXPECT_EQ(calculate_rank({{1,0},{1,1}}), 2);
+	EXPECT_EQ(calculate_rank({{0,1},{1,1}}), 2);
+
+	EXPECT_EQ(calculate_rank({{1,1},{1,1}}), 1);
+}
+
+TEST(binary_rank, calculate_rank_small_3_3) {
+	EXPECT_EQ(calculate_rank({{0,0,0},{0,0,0},{0,0,0}}), 0);
+	EXPECT_EQ(calculate_rank({{0,0,0},{0,0,0},{0,0,1}}), 1);
+	EXPECT_EQ(calculate_rank({{1,0,0},{0,1,0},{0,0,1}}), 3);
+	EXPECT_EQ(calculate_rank({{1,1,1},{0,1,0},{1,0,1}}), 2);
+	EXPECT_EQ(calculate_rank({{1,0,1},{1,1,0},{0,0,1}}), 3);
+}
+
+std::vector<binary_matrix> get_matrices(int matrix_size, uint64_t bits_low, uint64_t bits_high) {
+	using V = std::vector<uint64_t>;
+	std::vector<binary_matrix> ms;
+	for_each_matrix(V{bits_low, bits_high}, matrix_size, [&ms](const binary_matrix& m) {
+		ms.push_back(m);
+	});
+	return ms;
+}
+
+TEST(binary_rank, for_each_matrix_2_2) {
+	const auto ms = get_matrices(2, 0b1010111100000100, 0b0011);
+	EXPECT_EQ(ms.size(), 32);
+	EXPECT_EQ(binary_matrix({{0,0},{1,0}}), ms[0]);
+	EXPECT_EQ(binary_matrix({{0,0},{0,0}}), ms[1]);
+	EXPECT_EQ(binary_matrix({{1,1},{1,1}}), ms[2]);
+	EXPECT_EQ(binary_matrix({{0,1},{0,1}}), ms[3]);
+	EXPECT_EQ(binary_matrix({{1,1},{0,0}}), ms[16]);
+}
+
+TEST(binary_rank, for_each_matrix_3_3) {
+	constexpr uint64_t low = 0b111010111100000100 | static_cast<uint64_t>(0b1101101111) << 54;
+	const auto ms = get_matrices(3, low, 0b10000000);
+	EXPECT_EQ(ms.size(), 14);
+	EXPECT_EQ(binary_matrix({{0,0,1},{0,0,0}, {0,0,1}}), ms[0]);
+	EXPECT_EQ(binary_matrix({{1,1,1},{0,1,0}, {1,1,1}}), ms[1]);
+	EXPECT_EQ(binary_matrix({{1,1,1},{1,0,1}, {1,0,1}}), ms[6]);
+	EXPECT_EQ(binary_matrix({{1,0,0},{0,0,0}, {0,0,1}}), ms[7]);
+}
+
+TEST(binary_rank, no_change) {
+	using T = uint64_t;
+	const auto stat = binary_rank_stats<T>(1 << 10, test_stream(), 16);
+	EXPECT_NEAR(stat->value, 2.7868, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.24822, 1e-4);
+}
+
+TEST(binary_rank, large) {
+	using T = uint64_t;
+	const auto stat = binary_rank_stats<T>(1 << 21, test_stream(), 8);
+	EXPECT_NEAR(stat->value, 2.7868, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.24822, 1e-4);
+}
+
+TEST(binary_rank, rank_probability) {
+	EXPECT_NEAR(get_rank_probability(4,4), 0.3076171875, 1e-8);
+	EXPECT_NEAR(get_rank_probability(4,3), 0.5767822265, 1e-8);
+	EXPECT_NEAR(get_rank_probability(4,2), 0.1121520996, 1e-8);
+	EXPECT_NEAR(get_rank_probability(4,1), 0.0034332275, 1e-8);
+	EXPECT_NEAR(get_rank_probability(4,0), 0.0000152587, 1e-8);
+
+	EXPECT_NEAR(get_rank_probability(5,5), 0.2980041503, 1e-8);
+	EXPECT_NEAR(get_rank_probability(5,3), 0.1202881336, 1e-8);
+	EXPECT_NEAR(get_rank_probability(5,0), 2.9802322387e-8, 1e-8);
+
+	EXPECT_NEAR(get_rank_probability(64,64), 0.2887880950, 1e-8);
+	EXPECT_NEAR(get_rank_probability(64,63), 0.5775761901, 1e-8);
+	EXPECT_NEAR(get_rank_probability(64,62), 0.1283502644, 1e-8);
+	EXPECT_NEAR(get_rank_probability(64,0), 0, 1e-8);
+
+	EXPECT_NEAR(get_rank_probability(1024,1024), 0.2887880950, 1e-8);
+	EXPECT_NEAR(get_rank_probability(1024,1023), 0.5775761901, 1e-8);
+	EXPECT_NEAR(get_rank_probability(1024,1022), 0.1283502644, 1e-8);
+}
+
+TEST(binary_rank, rank_probabilities_small) {
+	const auto ps = get_rank_probabilities(4);
+	EXPECT_EQ(ps.size(), 5);
+	EXPECT_NEAR(ps[0], 0.3076, 1e-4);
+	EXPECT_NEAR(ps[1], 0.5767, 1e-4);
+}
+
+TEST(binary_rank, rank_probabilities_large) {
+	const auto ps = get_rank_probabilities(1000);
+	EXPECT_EQ(ps.size(), 1001);
+	EXPECT_NEAR(ps[0], 0.2887880950, 1e-4);
+	EXPECT_NEAR(ps[1], 0.5775761901, 1e-4);
+}
+
+}

--- a/unittest/src/statistics/binary_rank_test.cpp
+++ b/unittest/src/statistics/binary_rank_test.cpp
@@ -71,15 +71,15 @@ TEST(binary_rank, for_each_matrix_3_3) {
 TEST(binary_rank, no_change) {
 	using T = uint64_t;
 	const auto stat = binary_rank_stats<T>(1 << 10, test_stream(), 16);
-	EXPECT_NEAR(stat->value, 2.7868, 1e-4);
+	EXPECT_NEAR(stat->value, 2.7871, 1e-4);
 	EXPECT_NEAR(stat->p_value, 0.24822, 1e-4);
 }
 
 TEST(binary_rank, large) {
 	using T = uint64_t;
-	const auto stat = binary_rank_stats<T>(1 << 21, test_stream(), 8);
-	EXPECT_NEAR(stat->value, 2.7868, 1e-4);
-	EXPECT_NEAR(stat->p_value, 0.24822, 1e-4);
+	const auto stat = binary_rank_stats<T>(1 << 15, test_stream(), 32);
+	EXPECT_NEAR(stat->value, 0.9397, 1e-4);
+	EXPECT_NEAR(stat->p_value, 0.8158, 1e-4);
 }
 
 TEST(binary_rank, rank_probability) {
@@ -101,6 +101,8 @@ TEST(binary_rank, rank_probability) {
 	EXPECT_NEAR(get_rank_probability(1024,1024), 0.2887880950, 1e-8);
 	EXPECT_NEAR(get_rank_probability(1024,1023), 0.5775761901, 1e-8);
 	EXPECT_NEAR(get_rank_probability(1024,1022), 0.1283502644, 1e-8);
+	EXPECT_NEAR(get_rank_probability(1024,1021), 0.0052387863, 1e-8);
+	EXPECT_NEAR(get_rank_probability(1024,1020), 0.0000465669, 1e-8);
 }
 
 TEST(binary_rank, rank_probabilities_small) {
@@ -115,6 +117,21 @@ TEST(binary_rank, rank_probabilities_large) {
 	EXPECT_EQ(ps.size(), 1001);
 	EXPECT_NEAR(ps[0], 0.2887880950, 1e-4);
 	EXPECT_NEAR(ps[1], 0.5775761901, 1e-4);
+}
+
+TEST(binary_rank, get_matrix_size) {
+	using T = uint64_t;
+	EXPECT_EQ(get_matrix_size<T>(1<<10), 8);
+	EXPECT_EQ(get_matrix_size<T>(1<<11), 8);
+	EXPECT_EQ(get_matrix_size<T>(1<<12), 16);
+	EXPECT_EQ(get_matrix_size<T>(1<<13), 16);
+	EXPECT_EQ(get_matrix_size<T>(1<<14), 32);
+	EXPECT_EQ(get_matrix_size<T>(1<<15), 32);
+	EXPECT_EQ(get_matrix_size<T>(1<<16), 64);
+	EXPECT_EQ(get_matrix_size<T>(1<<17), 64);
+	EXPECT_EQ(get_matrix_size<T>(1<<18), 128);
+	EXPECT_EQ(get_matrix_size<T>(1<<19), 128);
+	EXPECT_EQ(get_matrix_size<T>(1<<20), 256);
 }
 
 }


### PR DESCRIPTION
Initial add of binary rank test. Disabled for now. Using less data since it becomes too slow.