### PR TITLE
Restrict n in slower tests

### DIFF
--- a/core/src/evaluate.h
+++ b/core/src/evaluate.h
@@ -9,7 +9,6 @@
 #include "util/timer.h"
 
 namespace tfr {
-
 template <typename T>
 struct test_setup {
 	std::string test_subject_name;
@@ -36,7 +35,6 @@ struct test_setup {
 
 
 namespace internal {
-
 using test_job_return = std::vector<test_result>;
 using test_job = job<test_job_return>;
 using test_jobs = jobs<test_job_return>;
@@ -82,12 +80,8 @@ test_jobs create_test_jobs(const uint64_t n, const test_setup<T>& setup) {
 	test_jobs jobs;
 	const auto& test_subject_name = setup.test_subject_name;
 	const auto& mix = setup.mix;
-	const auto power_of_two = std::floor(std::log2(n));
 	for (const auto& test : setup.tests) {
 		const auto& test_def = get_test_definition<T>(test);
-		if (power_of_two > test_def.max_power_of_two.value_or(10000)) {
-			continue;
-		}
 		for (const auto& source : setup.sources) {
 			if (test_def.test_mixer && mix) {
 				// mixer test
@@ -114,7 +108,6 @@ inline auto create_collector(test_battery_result& test_result) {
 		}
 	};
 }
-
 }
 
 template <typename T>
@@ -145,5 +138,4 @@ test_battery_result evaluate_multi_pass(const test_callback& result_callback,
 	}
 	return result;
 }
-
 }

--- a/core/src/statistics/avalanche.h
+++ b/core/src/statistics/avalanche.h
@@ -5,7 +5,6 @@
 #include "types.h"
 
 namespace tfr {
-
 template <typename T>
 std::vector<uint64_t> avalanche_generate_sac(uint64_t n, stream<T> stream, const mixer<T>& mixer) {
 	// @attn, using x = stream() directly will make all mixers fail for all counter streams with increments
@@ -59,14 +58,21 @@ inline std::optional<statistic> avalanche_bic_stats(const double n, const std::v
 
 template <typename T>
 sub_test_results avalanche_mixer_sac_test(uint64_t n, const stream<T>& stream, const mixer<T>& mixer) {
-	const auto counts = avalanche_generate_sac<T>(n, stream, mixer);
-	return main_sub_test(avalanche_sac_stats<T>(n, counts));
+	if (const auto slow_n = slow_down_quadratic_tests(n)) {
+		n = *slow_n;
+		const auto counts = avalanche_generate_sac<T>(n, stream, mixer);
+		return main_sub_test(avalanche_sac_stats<T>(n, counts));
+	}
+	return {};
 }
 
 template <typename T>
 sub_test_results avalanche_mixer_bic_test(uint64_t n, const stream<T>& stream, const mixer<T>& mixer) {
-	const auto counts = avalanche_generate_bic(n, stream, mixer);
-	return main_sub_test(avalanche_bic_stats(n, counts));
+	if (const auto slow_n = slow_down_cubic_tests(n)) {
+		n = *slow_n;
+		const auto counts = avalanche_generate_bic(n, stream, mixer);
+		return main_sub_test(avalanche_bic_stats(n, counts));
+	}
+	return {};
 }
-
 }

--- a/core/src/statistics/binary_rank.h
+++ b/core/src/statistics/binary_rank.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <deque>
+#include <vector>
 
 #include "chi2.h"
 #include "util/bitwise.h"
 #include "types.h"
-
-#include <vector>
 
 namespace tfr {
 // todo: unify with other matrix
@@ -120,12 +119,11 @@ uint64_t get_matrix_size(uint64_t n) {
 
 template <typename T>
 sub_test_results binary_rank_test(uint64_t n, const stream<T>& source) {
-	constexpr auto slow_down = 5. / 7.; // (2^25)^x=(2^35)
-	n = static_cast<uint64_t>(std::pow(n, slow_down));
-	if (n < 1 << 10) {
-		return {};
+	if (const auto slow_n = slow_down_cubic_tests(n)) {
+		n = *slow_n;
+		const auto matrix_size = get_matrix_size<T>(n);
+		return {{std::to_string(matrix_size), binary_rank_stats(n, source, matrix_size)}};
 	}
-	const auto matrix_size = get_matrix_size<T>(n);
-	return {{std::to_string(matrix_size), binary_rank_stats(n, source, matrix_size)}};
+	return {};
 }
 }

--- a/core/src/statistics/coupon.h
+++ b/core/src/statistics/coupon.h
@@ -9,7 +9,6 @@
 #include "util/algo.h"
 
 namespace tfr {
-
 template <typename T>
 std::vector<uint64_t> collect_coupons(uint64_t wanted_coupons, uint64_t tracked_draws, const T& data01) {
 	static_assert(std::is_floating_point_v<typename T::value_type>);
@@ -26,7 +25,7 @@ std::vector<uint64_t> collect_coupons(uint64_t wanted_coupons, uint64_t tracked_
 		if (coupons_collected.size() == wanted_coupons) {
 			std::size_t index = draw_count - wanted_coupons;
 			index = std::min(draws_histogram.size() - 1, index);
-			draws_histogram[index] ++;
+			draws_histogram[index]++;
 			draw_count = 0;
 			coupons_collected = {};
 		}
@@ -72,8 +71,10 @@ std::optional<statistic> coupon_stats(uint64_t n, const T& data01) {
 
 template <typename T>
 sub_test_results coupon_test(uint64_t n, const stream<T>& stream) {
-	return main_sub_test(coupon_stats(n, ranged_stream(rescale_type_to_01(stream), n)));
+	if (const auto slow_n = slow_down_cubic_tests(n)) {
+		n = *slow_n;
+		return main_sub_test(coupon_stats(n, ranged_stream(rescale_type_to_01(stream), n)));
+	}
+	return {};
 }
-
-
 }

--- a/core/src/statistics/permutation.h
+++ b/core/src/statistics/permutation.h
@@ -4,13 +4,12 @@
 #include "util/algo.h"
 
 namespace tfr {
-
 template <typename T>
 std::vector<uint64_t> get_permutation_histogram(const T& data, int window_size) {
 	static_assert(std::is_integral_v<typename T::value_type>);
 	std::vector<uint64_t> histogram(1ull << window_size);
 	sliding_bit_window(data, window_size, [&histogram](uint64_t v) {
-		histogram[v] ++;
+		histogram[v]++;
 	});
 	return histogram;
 }
@@ -30,11 +29,14 @@ std::optional<statistic> permutation_stat(const uint64_t n, const stream<T>& str
 }
 
 template <typename T>
-sub_test_results permutation_test(const uint64_t n, stream<T> source) {
-	auto sub_tests = split_test(n, 1000000, [&source](uint64_t size) {
-		return permutation_stat(size, source);
-	});
-	return sub_tests;
+sub_test_results permutation_test(uint64_t n, stream<T> source) {
+	if (const auto slow_n = slow_down_quadratic_tests(n)) {
+		n = *slow_n;
+		auto sub_tests = split_test(n, 1 << 20, [&source](uint64_t size) {
+			return permutation_stat(size, source);
+		});
+		return sub_tests;
+	}
+	return {};
 }
-
 }

--- a/core/src/test_definitions.h
+++ b/core/src/test_definitions.h
@@ -11,14 +11,12 @@
 #include "statistics/waldwolfowitz.h"
 
 namespace tfr {
-
 template <typename T>
 struct test_definition {
 	test_type type{};
 	stream_test<T> test_stream;
 	mixer_test<T> test_mixer;
 	std::string name;
-	std::optional<int> max_power_of_two;
 };
 
 template <typename T>
@@ -37,7 +35,7 @@ std::vector<test_definition<T>> get_tests() {
 
 		// mixer tests
 		{test_type::sac, {}, avalanche_mixer_sac_test<T>, "sac"},
-		{test_type::bic, {}, avalanche_mixer_bic_test<T>, "bic", 25},
+		{test_type::bic, {}, avalanche_mixer_bic_test<T>, "bic"},
 	};
 }
 
@@ -63,6 +61,4 @@ inline std::vector<test_type> default_test_types = []() {
 	}
 	return types;
 }();
-
-
 }

--- a/core/src/types.h
+++ b/core/src/types.h
@@ -13,7 +13,6 @@
 #include "util/math.h"
 
 namespace tfr {
-
 template <typename T>
 using stream_factory = std::function<stream<T>()>;
 
@@ -145,6 +144,19 @@ inline sub_test_results split_test(const uint64_t n, const uint64_t max_size, co
 	return results;
 }
 
+inline std::optional<uint64_t> slow_down(uint64_t n, double exp) {
+	const auto slow_n = static_cast<uint64_t>(std::pow(n, exp));
+	return slow_n >= 1 << 10 ? slow_n : std::optional<uint64_t>{};
+}
+
+inline std::optional<uint64_t> slow_down_quadratic_tests(uint64_t n) {
+	return slow_down(n, 6. / 7.); // (2^35)^x=(2^30)
+}
+
+inline std::optional<uint64_t> slow_down_cubic_tests(uint64_t n) {
+	return slow_down(n, 5. / 7.); // (2^35)^x=(2^25)
+}
+
 ///////////////////////////////////////////////////////////////
 /// DATA TYPES
 ///////////////////////////////////////////////////////////////
@@ -174,5 +186,4 @@ inline data_fn mul(const data_fn& a, const data_fn& b) {
 inline unsigned int default_max_threads() {
 	return std::max(std::thread::hardware_concurrency() - 4, 2u);
 }
-
 }

--- a/tool/src/command/inspect_test_command.h
+++ b/tool/src/command/inspect_test_command.h
@@ -12,7 +12,6 @@
 #include "util/test_setups.h"
 
 namespace tfr {
-
 template <typename T>
 streams<T> create_fail_sources() {
 	const auto& mix = get_default_mixer<T>();
@@ -141,7 +140,7 @@ void inspect_test_command() {
 using per_test_result = std::map<std::string, std::map<std::string, std::string>>;
 
 inline auto create_per_test_callback(per_test_result& result,
-                                     std::function<std::string(const test_battery_result&)> extract_property,
+                                     const std::function<std::string(const test_battery_result&)>& extract_property,
                                      bool print_intermediate_results = true) {
 	return [&result, print_intermediate_results, extract_property](const test_battery_result& br, bool is_last) {
 		bool proceed = !is_last;
@@ -164,23 +163,28 @@ inline auto create_per_test_callback(per_test_result& result,
 template <typename T>
 void write(const std::string& name, const per_test_result& result) {
 	std::stringstream ss;
-	ss << ";";
+	ss << "name|";
 	for (const auto& test : get_tests<T>()) {
-		ss << test.name << ";";
+		ss << test.name << "|";
 	}
 	ss << "\n";
+	for (int i = 0; i < get_tests<T>().size(); ++i) {
+		ss << "-|";
+	}
+	ss << "-\n";
+
 	for (const auto& e : result) {
-		ss << e.first << ";";
+		ss << e.first << "|";
 		for (const auto& test : get_tests<T>()) {
 			auto it = e.second.find(test.name);
 			if (it != e.second.end()) {
 				ss << it->second;
 			}
-			ss << ";";
+			ss << "|";
 		}
 		ss << "\n";
 	}
-	write(get_config().result_dir() + name + "_per_test" + std::to_string(bit_sizeof<T>()) + ".txt", ss.str());
+	write(get_config().result_dir() + name + "_per_test" + std::to_string(bit_sizeof<T>()) + ".md", ss.str());
 }
 
 
@@ -240,6 +244,4 @@ void inspect_test_speed_command() {
 		write<T>("speed", result);
 	}
 }
-
-
 }

--- a/unittest/src/statistics/avalanche_test.cpp
+++ b/unittest/src/statistics/avalanche_test.cpp
@@ -24,13 +24,19 @@ TEST(avalanche, sac_data_large) {
 }
 
 TEST(avalanche, sac_no_change) {
-	const auto r = avalanche_mixer_sac_test(50, test_stream(), mix64::mx3).front().stats;
+	using T = uint64_t;
+	constexpr auto n = 50;
+	const auto counts = avalanche_generate_sac<T>(n, test_stream(), mix64::mx3);
+	const auto r = avalanche_sac_stats<T>(n, counts);
 	EXPECT_NEAR(r->value, 17.1819, 1e-4);
 	EXPECT_NEAR(r->p_value, 0.7532, 1e-4);
 }
 
 TEST(avalanche, bic_no_change) {
-	const auto r = avalanche_mixer_bic_test(50, test_stream(), mix64::mx3).front().stats;
+	using T = uint64_t;
+	constexpr auto n = 50;
+	const auto counts = avalanche_generate_bic<T>(n, test_stream(), mix64::mx3);
+	const auto r = avalanche_bic_stats(n, counts);
 	EXPECT_NEAR(r->value, 4020.4800, 1e-4);
 	EXPECT_NEAR(r->p_value, 0.7942, 1e-4);
 }

--- a/unittest/src/statistics/coupon_test.cpp
+++ b/unittest/src/statistics/coupon_test.cpp
@@ -6,7 +6,6 @@
 
 
 namespace tfr {
-
 TEST(coupon, collect_coupons) {
 	using D = std::vector<double>;
 	using T = std::vector<uint64_t>;
@@ -60,9 +59,9 @@ TEST(coupon, expected_probabilities_10_20) {
 }
 
 TEST(coupon, coupon_no_change) {
-	const auto r = coupon_test(10000, test_stream()).front().stats;
+	constexpr auto n = 10000;
+	const auto r = coupon_stats(n, ranged_stream(rescale_type_to_01(test_stream()), n));
 	EXPECT_NEAR(r->value, 29.3991, 1e-4);
 	EXPECT_NEAR(r->p_value, 0.2054, 1e-4);
 }
-
 }

--- a/unittest/src/statistics/permutation_test.cpp
+++ b/unittest/src/statistics/permutation_test.cpp
@@ -13,7 +13,7 @@ std::vector<uint64_t> get_histogram(const std::vector<T>& d) {
 }
 
 TEST(permutation, no_change) {
-	const auto r = permutation_test(1000, test_stream()).front().stats;
+	const auto r = permutation_stat(1000, test_stream());
 	EXPECT_NEAR(r->value, 23.2259, 1e-4);
 	EXPECT_NEAR(r->p_value, 0.07945, 1e-4);
 }
@@ -66,8 +66,8 @@ TEST(permutation, no_change_8) {
 	}
 	const auto s8 = create_stream_from_data_by_ref("test", data);
 	const auto r = permutation_test(data.size(), s8).front().stats;
-	EXPECT_NEAR(r->value, 523.6892, 1e-4);
-	EXPECT_NEAR(r->p_value, .3392, 1e-4);
+	EXPECT_NEAR(r->value, 118.4100, 1e-4);
+	EXPECT_NEAR(r->p_value, 0.6948, 1e-4);
 }
 
 }


### PR DESCRIPTION
This will result in some failures to occur later but gives more chance to other tests to find it earlier.